### PR TITLE
(Fix) Add python3 support for remote node core branch

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -6,6 +6,8 @@
 ###
 
 ---
+ansible_python_interpreter: /usr/bin/python3
+
 ssh_root:
     - "{{ lookup('file', 'files/admins.pub') }}"
 


### PR DESCRIPTION
Added line to group_vars/all.example to force remote node to use python3 instead of python2.7
reason being: fresh install of ubuntu 16.04 does not have python2.7 by default and it eases deployment process on cloud services other than AWS