### PR TITLE
(Fix) moved ansible_python_interpreter from all.example to all.network

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -6,8 +6,6 @@
 ###
 
 ---
-ansible_python_interpreter: /usr/bin/python3
-
 ssh_root:
     - "{{ lookup('file', 'files/admins.pub') }}"
 

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -1,4 +1,6 @@
 ---
+ansible_python_interpreter: /usr/bin/python3
+
 ssh_root:
     - "{{ lookup('file', 'files/admins.pub') }}"
 


### PR DESCRIPTION
Previous merge was into wrong config file