### PR TITLE
Options to create archive-nodes

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -59,6 +59,7 @@ bootnode_instance_type: "t2.large"
 bootnode_instance_name: "bootnode"
 bootnode_count_instances: "1"
 bootnode_security_group: "bootnode-security"
+bootnode_archive: "off"
 
 #netstat
 netstat_instance_type: "t2.large"
@@ -71,12 +72,14 @@ validator_instance_type: "t2.large"
 validator_instance_name: "validator"
 validator_count_instances: "1"
 validator_security_group: "validator-security"
+validator_archive: "off"
 
 #moc
 moc_instance_type: "t2.large"
 moc_instance_name: "moc"
 moc_count_instances: "1"
 moc_security_group: "moc-security"
+moc_archive: "off"
 
 #explorer
 explorer_instance_type: "t2.large"

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -36,6 +36,7 @@ bootnode_instance_type: "t2.large"
 bootnode_instance_name: "bootnode"
 bootnode_count_instances: "1"
 bootnode_security_group: "bootnode-security"
+bootnode_archive: "off"
 
 #netstat
 netstat_instance_type: "t2.large"
@@ -48,12 +49,14 @@ validator_instance_type: "t2.large"
 validator_instance_name: "validator"
 validator_count_instances: "1"
 validator_security_group: "validator-security"
+validator_archive: "off"
 
 #moc
 moc_instance_type: "t2.large"
 moc_instance_name: "moc"
 moc_count_instances: "1"
 moc_security_group: "moc-security"
+moc_archive: "off"
 
 #explorer
 explorer_instance_type: "t2.large"

--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -1,11 +1,38 @@
 [parity]
 chain = "spec.json"
 base_path = "parity_data"
+{% if bootnode_archive|default("off") == "on" %}
+auto_update = "all"
+{% endif %}
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
+{% if bootnode_archive|default("off") == "on" %}
+snapshot_peers = 500
+discovery = false
+allow_ips = "public"
+{% endif %}
+
+{% if bootnode_archive|default("off") == "on" %}
+[ui]
+disable = true
+
+[dapps]
+disable = true
+
+[snapshots]
+disable_periodic = false
+
+[footprint]
+pruning = "archive"
+pruning_history = 1200
+fat_db = "on"
+cache_size_db = 12000
+min_peers = 5
+max_peers = 10
+{% endif %}
 
 [rpc]
 #apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]

--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -15,6 +15,11 @@ discovery = false
 allow_ips = "public"
 {% endif %}
 
+[rpc]
+#apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
+apis = ["web3","eth","net"]
+threads = 4
+
 {% if bootnode_archive|default("off") == "on" %}
 [ui]
 disable = true
@@ -33,11 +38,6 @@ cache_size_db = 12000
 min_peers = 5
 max_peers = 10
 {% endif %}
-
-[rpc]
-#apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
-apis = ["web3","eth","net"]
-threads = 4
 
 [misc]
 log_file = "{{ home }}/logs/parity.log"

--- a/roles/moc/templates/node.toml.j2
+++ b/roles/moc/templates/node.toml.j2
@@ -1,11 +1,19 @@
 [parity]
 chain = "spec.json"
 base_path = "parity_data"
+{% if moc_archive|default("off") == "on" %}
+auto_update = "all"
+{% endif %}
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
+{% if moc_archive|default("off") == "on" %}
+snapshot_peers = 500
+discovery = false
+allow_ips = "public"
+{% endif %}
 
 [rpc]
 apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
@@ -20,6 +28,25 @@ force_sealing = true
 engine_signer = "{{ MOC_ADDRESS }}"
 gas_floor_target = "{{ BLK_GAS_LIMIT }}"
 reseal_on_txs = "none"
+
+{% if moc_archive|default("off") == "on" %}
+[ui]
+disable = true
+
+[dapps]
+disable = true
+
+[snapshots]
+disable_periodic = false
+
+[footprint]
+pruning = "archive"
+pruning_history = 1200
+fat_db = "on"
+cache_size_db = 12000
+min_peers = 5
+max_peers = 10
+{% endif %}
 
 [misc]
 log_file = "{{ home }}/logs/parity.log"

--- a/roles/poa-parity/templates/poa-parity.j2
+++ b/roles/poa-parity/templates/poa-parity.j2
@@ -5,6 +5,9 @@ After=network.target
 User={{ username }}
 Group={{ username }}
 WorkingDirectory=/home/{{ username }}
+{% if validator_archive|default("off") == "on" or bootnode_archive|default("off") == "on" or moc_archive|default("off") == "on" %}
+Environment=RUST_BACKTRACE=1
+{% endif %}
 ExecStart=/home/{{ username }}/parity --config=node.toml
 Restart=always
 [Install]

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -1,11 +1,19 @@
 [parity]
 chain = "spec.json"
 base_path = "parity_data"
+{% if validator_archive|default("off") == "on" %}
+auto_update = "all"
+{% endif %}
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
+{% if validator_archive|default("off") == "on" %}
+snapshot_peers = 500
+discovery = false
+allow_ips = "public"
+{% endif %}
 
 [rpc]
 apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
@@ -20,6 +28,25 @@ force_sealing = true
 engine_signer = "{{ MINING_ADDRESS }}"
 gas_floor_target = "{{ BLK_GAS_LIMIT }}"
 reseal_on_txs = "none"
+
+{% if validator_archive|default("off") == "on" %}
+[ui]
+disable = true
+
+[dapps]
+disable = true
+
+[snapshots]
+disable_periodic = false
+
+[footprint]
+pruning = "archive"
+pruning_history = 1200
+fat_db = "on"
+cache_size_db = 12000
+min_peers = 5
+max_peers = 10
+{% endif %}
 
 [misc]
 log_file = "{{ home }}/logs/parity.log"


### PR DESCRIPTION
Add options `bootnode_archive`, `moc_archive`, `validator_archive` with possible values `"on"`/`"off"` to corresponding roles to create a node that keeps record of all txs.
This closes #42 
