### PR TITLE
Core: Add tracing for archiving nodes

### DIFF
--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -31,6 +31,7 @@ disable = true
 disable_periodic = false
 
 [footprint]
+tracing = "on"
 pruning = "archive"
 pruning_history = 1200
 fat_db = "on"

--- a/roles/moc/templates/node.toml.j2
+++ b/roles/moc/templates/node.toml.j2
@@ -40,6 +40,7 @@ disable = true
 disable_periodic = false
 
 [footprint]
+tracing = "on"
 pruning = "archive"
 pruning_history = 1200
 fat_db = "on"

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -40,6 +40,7 @@ disable = true
 disable_periodic = false
 
 [footprint]
+tracing = "on"
 pruning = "archive"
 pruning_history = 1200
 fat_db = "on"


### PR DESCRIPTION
Add `tracing = "on"` parameter in node.toml files for node in archiving mode.