### PR TITLE
Update AWS ami

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -23,7 +23,7 @@ access_key: "INSERT KEY HERE"
 secret_key: "INSERT SECRET HERE"
 
 awskeypair_name: "keypairname"
-image: "ami-9d04e4e5"
+image: "ami-0b383171"
 region: "us-west-2"
 vpc_subnet_id: "subnet-ID-number"
 

--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -24,7 +24,7 @@ secret_key: "INSERT SECRET HERE"
 
 awskeypair_name: "keypairname"
 image: "ami-0b383171"
-region: "us-west-2"
+region: "us-east-1"
 vpc_subnet_id: "subnet-ID-number"
 
 NODE_FULLNAME: "INSERT NODENAME"

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -17,7 +17,7 @@ ntpservers:
   - "server 2.us.pool.ntp.org"
   - "server 3.us.pool.ntp.org"
 
-image: "ami-9d04e4e5"
+image: "ami-0b383171"
 region: "us-west-2"
 
 NODE_PWD: "node.pwd" # don't change this one

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -18,7 +18,7 @@ ntpservers:
   - "server 3.us.pool.ntp.org"
 
 image: "ami-0b383171"
-region: "us-west-2"
+region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"


### PR DESCRIPTION
* **Not so important**: in master branch `group_vars/all.example` and `group_vars/all.network` files contain different default values for region and ami in comparison with `core` and `sokol` branches

* **More important**: update current ami version. When this will later be merged into `core` and `sokol`, ami will be updated to the latest version (2018-02-05) for `us-east-1, 16.04 LTS, amd64, hvm:ebs-ssd` (see https://cloud-images.ubuntu.com/locator/ec2/ )