### PR TITLE
Sokol: Update default parity version to 1.9.2

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -52,8 +52,8 @@ BLK_GAS_LIMIT: "6700000"
 NODE_PWD: "node.pwd"
 
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://github.com/poanetwork/binary-releases/releases/download/1.8.4/parity"
-PARITY_BIN_SHA256: "a7794b04f056cb93cd6ad27be3f7a07ceeb2f340ddf4635306b020b6bfc3c2ae"
+PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.9.2/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "3604a030388cd2c22ebe687787413522106c697610426e09b3c5da4fe70bbd33"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 


### PR DESCRIPTION
Almost all nodes are updated to `1.9.2` on sokol now.
Change default value in playbook to `1.9.2` as well so that newly-created nodes would run it.
