### PR TITLE
Sokol: Update parity version to 1.9.2 in all.network

### DIFF
--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -22,8 +22,8 @@ region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://github.com/poanetwork/binary-releases/releases/download/1.8.4/parity"
-PARITY_BIN_SHA256: "a7794b04f056cb93cd6ad27be3f7a07ceeb2f340ddf4635306b020b6bfc3c2ae"
+PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.9.2/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "3604a030388cd2c22ebe687787413522106c697610426e09b3c5da4fe70bbd33"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 


### PR DESCRIPTION
In https://github.com/poanetwork/deployment-playbooks/pull/70 also should have updated version and checksum in `all.network` file