### PR TITLE
Sokol: upd bootnode params to fit 1.9.2 (part I)

### DIFF
--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -18,7 +18,7 @@ allow_ips = "public"
 [rpc]
 #apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
 apis = ["web3","eth","net" {{ ', "parity", "parity_set", "shh"' if bootnode_orchestrator|default("off") == "on" else '' }}]
-threads = 4
+processing_threads = 4
 
 {% if bootnode_archive|default("off") == "on" %}
 [ui]
@@ -36,8 +36,6 @@ pruning = "archive"
 pruning_history = 1200
 fat_db = "on"
 cache_size_db = 12000
-min_peers = 5
-max_peers = 10
 {% endif %}
 
 [misc]


### PR DESCRIPTION
Some parameters were renamed in parity 1.9.2:
* `threads` -> `processing_threads`
* `min_peers`, `max_peers` (only for archiving bootnodes) - not sure how it worked in the first place, because they were placed in `[footprint]` section. They are not needed actually, so remove them.
