### PR TITLE
Sokol: upd bootnode params to fit 1.9.2 (part II)

### DIFF
--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -19,6 +19,7 @@ allow_ips = "public"
 #apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
 apis = ["web3","eth","net" {{ ', "parity", "parity_set", "shh"' if bootnode_orchestrator|default("off") == "on" else '' }}]
 processing_threads = 4
+cors=["all"]
 
 {% if bootnode_archive|default("off") == "on" %}
 [ui]

--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -18,7 +18,7 @@ allow_ips = "public"
 [rpc]
 #apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
 apis = ["web3","eth","net" {{ ', "parity", "parity_set", "shh"' if bootnode_orchestrator|default("off") == "on" else '' }}]
-threads = 4
+processing_threads = 4
 
 {% if bootnode_archive|default("off") == "on" %}
 [ui]
@@ -36,8 +36,6 @@ pruning = "archive"
 pruning_history = 1200
 fat_db = "on"
 cache_size_db = 12000
-min_peers = 5
-max_peers = 10
 {% endif %}
 
 [misc]


### PR DESCRIPTION
In parity 1.9.2 parity's jsonrpc by default assumes all `Host`s to be blacklisted, in contrast with previous version where they were whitelisted by default. So now without setting `cors` option on bootnodes corresponding to rpc endpoint, sites like MyEtherWallet can't connect to the network.

I separate this PR from [Part I](https://github.com/poanetwork/deployment-playbooks/pull/72), because this one will probably raise some discussion, so Part I can be merged independently.

For future, I propose we separate existing role "bootnode" into two:
* "bootnode" bootnode - accessible only for peer discovery, without nginx and cors. Maybe a cluster of them can use orchestrator
* "rpc" node - the one users can connect to to use rpc

these two types might require different settings and resources

