### PR TITLE
Core: updates for parity 1.9.2

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -52,8 +52,8 @@ BLK_GAS_LIMIT: "6700000"
 NODE_PWD: "node.pwd"
 
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://github.com/poanetwork/binary-releases/releases/download/1.8.4/parity"
-PARITY_BIN_SHA256: "a7794b04f056cb93cd6ad27be3f7a07ceeb2f340ddf4635306b020b6bfc3c2ae"
+PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.9.2/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "3604a030388cd2c22ebe687787413522106c697610426e09b3c5da4fe70bbd33"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -22,8 +22,8 @@ region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://github.com/poanetwork/binary-releases/releases/download/1.8.4/parity"
-PARITY_BIN_SHA256: "a7794b04f056cb93cd6ad27be3f7a07ceeb2f340ddf4635306b020b6bfc3c2ae"
+PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.9.2/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "3604a030388cd2c22ebe687787413522106c697610426e09b3c5da4fe70bbd33"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 

--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -18,7 +18,8 @@ allow_ips = "public"
 [rpc]
 #apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
 apis = ["web3","eth","net" {{ ', "parity", "parity_set", "shh"' if bootnode_orchestrator|default("off") == "on" else '' }}]
-threads = 4
+processing_threads = 4
+cors=['all']
 
 {% if bootnode_archive|default("off") == "on" %}
 [ui]
@@ -36,8 +37,6 @@ pruning = "archive"
 pruning_history = 1200
 fat_db = "on"
 cache_size_db = 12000
-min_peers = 5
-max_peers = 10
 {% endif %}
 
 [misc]


### PR DESCRIPTION
Related to https://github.com/poanetwork/deployment-playbooks/issues/85
Updates from _sokol_:
* Parity version and checksums (https://github.com/poanetwork/deployment-playbooks/pull/70, https://github.com/poanetwork/deployment-playbooks/pull/71)
* Bootnode config (https://github.com/poanetwork/deployment-playbooks/pull/72, https://github.com/poanetwork/deployment-playbooks/pull/73)
