### PR TITLE
Local deployment environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ group_vars/netstat
 group_vars/moc
 
 hosts
+
+.vagrant/*
+ubuntu-xenial-16.04-cloudimg-console.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+clean:
+	@vagrant destroy --force
+
+test:
+	for i in "validator" "explorer" "moc" "bootnode" "netstat"; do \
+		echo "Verifying $$i..\n"; \
+		vagrant up $$i; \
+		vagrant destroy --force $$i; \
+		echo "Done $$i verification\n"; \
+	done

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 Vagrant.configure("2") do |config|
 
   servers = [ "validator", "explorer", "moc", "bootnode", "netstat" ]
-  # platform = "ubuntu/xenial64"
+
   if ENV["poa_platform"] == "ubuntu"
     platform = "ubuntu/xenial64"
   elsif ENV["poa_platform"] == "centos"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,10 +4,19 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.hostname = "validator"
-  config.vm.network "private_network", ip: "192.168.57.10"
+
+  config.vm.define "vm-01"
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = "1024"
+    vb.memory = 1024
+    vb.cpus = 1
+    vb.name = "validator"
   end
-  
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "site.yml"
+    ansible.groups = {
+      "validator" => ["vm-01"]
+    }
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,10 @@ Vagrant.configure("2") do |config|
           "bootnode" => ["bootnode"]
         }
       end
+
+      node.vm.provision :shell do |shell|
+        shell.path = "./tests/#{machine}.sh"
+      end
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+  config.vm.hostname = "validator"
+  config.vm.network "private_network", ip: "192.168.57.10"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+  end
+  
+end

--- a/tests/bootnode.sh
+++ b/tests/bootnode.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "This is a stub for bootnode integration tests"

--- a/tests/explorer.sh
+++ b/tests/explorer.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "This is a stub for explorer integration tests"

--- a/tests/moc.sh
+++ b/tests/moc.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "This is a stub for moc integration tests"

--- a/tests/netstat.sh
+++ b/tests/netstat.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "This is a stub for netstat integration tests"

--- a/tests/validator.sh
+++ b/tests/validator.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "This is a stub for validator integration tests"


### PR DESCRIPTION
This PR adds code for local testing of the playbooks.

It uses Vagrant and VirtualBox for running virtual machines. In this virtual machines vagrant runs ansible playbooks and integration tests after completion.

`poa_platform` enviornmental variable select the platform to run tests on - `ubuntu` or `centos`.

`Makefile` automates one-by-one test of all the playbooks types. It takes about 20 minutes on i5 to pass full set of tests.

One may want to run provisioning for only one machine: `vagrant up explorer`.