### PR TITLE
Remove unused variables related to dns and ntp servers

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -9,16 +9,6 @@
 ssh_root:
     - "{{ lookup('file', 'files/admins.pub') }}"
 
-snmp_syslocation: "USA"
-snmp_ipsubnet:    "172.16.0.0/16"
-
-nameservers:
-  - "8.8.8.8"
-  - "8.8.4.4"
-
-ntpservers:
-  - ""
-
 access_key: "INSERT KEY HERE"
 secret_key: "INSERT SECRET HERE"
 

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -4,19 +4,6 @@ ansible_python_interpreter: /usr/bin/python3
 ssh_root:
     - "{{ lookup('file', 'files/admins.pub') }}"
 
-snmp_syslocation: "USA"
-snmp_ipsubnet:    "172.16.0.0/16"
-
-nameservers:
-  - "8.8.8.8"
-  - "8.8.4.4"
-
-ntpservers:
-  - "server 0.us.pool.ntp.org"
-  - "server 1.us.pool.ntp.org"
-  - "server 2.us.pool.ntp.org"
-  - "server 3.us.pool.ntp.org"
-
 image: "ami-0b383171"
 region: "us-east-1"
 


### PR DESCRIPTION
Remove variables `snmp_syslocation`, `snmp_ipsubnet`, `nameservers`, `ntpservers` as they are not used currently. These settings are usually provided by the hosting platform.

Closes #88 #56