### PR TITLE
(Upd 1.10) Explicitly disable ui and dapps for bootnodes

### DIFF
--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -21,13 +21,13 @@ apis = ["web3","eth","net" {{ ', "parity", "parity_set", "shh"' if bootnode_orch
 processing_threads = 4
 cors=["all"]
 
-{% if bootnode_archive|default("off") == "on" %}
 [ui]
 disable = true
 
 [dapps]
 disable = true
 
+{% if bootnode_archive|default("off") == "on" %}
 [snapshots]
 disable_periodic = false
 


### PR DESCRIPTION
Before, trying to open rpc port via GET (e.g. http://192.0.2.1:8545) would redirect to localhost. In 1.10 this is no longer the case, instead a page with 404 error is returned

![](http://i.imgur.com/6nzZuAi.png)

Just to be safe, I propose we explicitly disable ui and dapps in config
