### PR TITLE
(SOKOL UPD 1.10) Revert explicitly disabling dapps on bootnodes

### DIFF
--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -24,9 +24,6 @@ cors=["all"]
 [ui]
 disable = true
 
-[dapps]
-disable = true
-
 {% if bootnode_archive|default("off") == "on" %}
 [snapshots]
 disable_periodic = false


### PR DESCRIPTION
This PR partially reverts the previous one (https://github.com/poanetwork/deployment-playbooks/pull/105) as it turns out that `/api/health` is a "built-in" dapp
We can get info on sync status, number of peers from jsonrpc, but not on time drift. Since we don't have any actual dapps stored in parity, I think we can keep this option enabled