### PR TITLE
Remove unnecesary envvar declaration

### DIFF
--- a/roles/explorer/templates/poa-chain-explorer.j2
+++ b/roles/explorer/templates/poa-chain-explorer.j2
@@ -6,7 +6,6 @@ Type=oneshot
 RemainAfterExit=true
 User={{ username }}
 Group={{ username }}
-Environment=MYVAR=myval
 WorkingDirectory=/home/{{ username }}/chain-explorer
 ExecStart=/usr/bin/pm2 startOrRestart app.json
 [Install]

--- a/roles/netstat/templates/poa-dashboard.j2
+++ b/roles/netstat/templates/poa-dashboard.j2
@@ -4,7 +4,6 @@ After=network.target
 [Service]
 User={{ username }}
 Group={{ username }}
-Environment=MYVAR=myval
 WorkingDirectory=/home/{{ username }}/eth-netstats
 Restart=always
 ExecStart=/usr/bin/npm start

--- a/roles/poa-netstats/templates/poa-netstats.j2
+++ b/roles/poa-netstats/templates/poa-netstats.j2
@@ -6,7 +6,6 @@ Type=oneshot
 RemainAfterExit=true
 User={{ username }}
 Group={{ username }}
-Environment=MYVAR=myval
 WorkingDirectory=/home/{{ username }}/eth-net-intelligence-api
 ExecStart=/usr/bin/pm2 startOrRestart app.json
 [Install]

--- a/roles/poa-parity/templates/poa-chain-explorer.j2
+++ b/roles/poa-parity/templates/poa-chain-explorer.j2
@@ -6,7 +6,6 @@ Type=oneshot
 RemainAfterExit=true
 User={{ username }}
 Group={{ username }}
-Environment=MYVAR=myval
 WorkingDirectory=/home/{{ username }}/chain-explorer
 ExecStart=/usr/bin/pm2 startOrRestart app.json
 [Install]

--- a/roles/poa-parity/templates/poa-dashboard.j2
+++ b/roles/poa-parity/templates/poa-dashboard.j2
@@ -4,7 +4,6 @@ After=network.target
 [Service]
 User={{ username }}
 Group={{ username }}
-Environment=MYVAR=myval
 WorkingDirectory=/home/{{ username }}/eth-netstats
 Restart=always
 ExecStart=/usr/bin/npm start

--- a/roles/poa-parity/templates/poa-netstats.j2
+++ b/roles/poa-parity/templates/poa-netstats.j2
@@ -6,7 +6,6 @@ Type=oneshot
 RemainAfterExit=true
 User={{ username }}
 Group={{ username }}
-Environment=MYVAR=myval
 WorkingDirectory=/home/{{ username }}/eth-net-intelligence-api
 ExecStart=/usr/bin/pm2 startOrRestart app.json
 [Install]

--- a/roles/poa-parity/templates/poa-pm2.j2
+++ b/roles/poa-parity/templates/poa-pm2.j2
@@ -6,7 +6,6 @@ Type=oneshot
 RemainAfterExit=true
 User={{ username }}
 Group={{ username }}
-Environment=MYVAR=myval
 WorkingDirectory=/home/{{ username }}
 ExecStart=/usr/bin/pm2 ping
 [Install]

--- a/roles/poa-pm2/templates/poa-pm2.j2
+++ b/roles/poa-pm2/templates/poa-pm2.j2
@@ -6,7 +6,6 @@ Type=oneshot
 RemainAfterExit=true
 User={{ username }}
 Group={{ username }}
-Environment=MYVAR=myval
 WorkingDirectory=/home/{{ username }}
 ExecStart=/usr/bin/pm2 ping
 [Install]


### PR DESCRIPTION
Looks like there was a typo in template unnecesarry env variable. Doesn't affect anything actually, but I beleive should be cleaned up. 
#112 Is the corresponding issue