### PR TITLE
(Core) update security group namings

### DIFF
--- a/bootnode.yml
+++ b/bootnode.yml
@@ -7,11 +7,11 @@
     ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: bootnode-security
+      name: "{{ bootnode_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
-#      purge_rules_egress: true
-#      purge_rules: true
+      purge_rules_egress: false
+      purge_rules: false
       rules:
         - proto: tcp
           from_port: 22

--- a/explorer.yml
+++ b/explorer.yml
@@ -7,9 +7,11 @@
     ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: explorer-security
+      name: "{{ explorer_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
+      purge_rules_egress: false
+      purge_rules: false
       rules:
         - proto: tcp
           from_port: 22

--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -61,7 +61,7 @@ ORCHESTRATOR_BIN_SHA256: ""
 bootnode_instance_type: "t2.large"
 bootnode_instance_name: "bootnode"
 bootnode_count_instances: "1"
-bootnode_security_group: "bootnode-security"
+bootnode_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-bootnode-security"
 bootnode_archive: "off"
 bootnode_orchestrator: "off"
 
@@ -69,27 +69,27 @@ bootnode_orchestrator: "off"
 netstat_instance_type: "t2.large"
 netstat_instance_name: "netstat"
 netstat_count_instances: "1"
-netstat_security_group: "netstat-security"
+netstat_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-netstat-security"
 
 #validator
 validator_instance_type: "t2.large"
 validator_instance_name: "validator"
 validator_count_instances: "1"
-validator_security_group: "validator-security"
+validator_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-validator-security"
 validator_archive: "off"
 
 #moc
 moc_instance_type: "t2.large"
 moc_instance_name: "moc"
 moc_count_instances: "1"
-moc_security_group: "moc-security"
+moc_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-moc-security"
 moc_archive: "off"
 
 #explorer
 explorer_instance_type: "t2.large"
 explorer_instance_name: "explorer"
 explorer_count_instances: "1"
-explorer_security_group: "explorer-security"
+explorer_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-explorer-security"
 
 #restrict network access to instances
 allow_bootnode_ssh: true

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -40,7 +40,7 @@ BLK_GAS_LIMIT: "8000000"
 bootnode_instance_type: "t2.large"
 bootnode_instance_name: "bootnode"
 bootnode_count_instances: "1"
-bootnode_security_group: "bootnode-security"
+bootnode_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-bootnode-security"
 bootnode_archive: "off"
 bootnode_orchestrator: "off"
 
@@ -48,27 +48,27 @@ bootnode_orchestrator: "off"
 netstat_instance_type: "t2.large"
 netstat_instance_name: "netstat"
 netstat_count_instances: "1"
-netstat_security_group: "netstat-security"
+netstat_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-netstat-security"
 
 #validator
 validator_instance_type: "t2.large"
 validator_instance_name: "validator"
 validator_count_instances: "1"
-validator_security_group: "validator-security"
+validator_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-validator-security"
 validator_archive: "off"
 
 #moc
 moc_instance_type: "t2.large"
 moc_instance_name: "moc"
 moc_count_instances: "1"
-moc_security_group: "moc-security"
+moc_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-moc-security"
 moc_archive: "off"
 
 #explorer
 explorer_instance_type: "t2.large"
 explorer_instance_name: "explorer"
 explorer_count_instances: "1"
-explorer_security_group: "explorer-security"
+explorer_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-explorer-security"
 
 #restrict network access to instances
 allow_bootnode_ssh: true

--- a/moc.yml
+++ b/moc.yml
@@ -7,9 +7,11 @@
     ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: moc-security
+      name: "{{ moc_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
+      purge_rules_egress: false
+      purge_rules: false
       rules:
         - proto: tcp
           from_port: 22

--- a/netstat.yml
+++ b/netstat.yml
@@ -7,9 +7,11 @@
     ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: netstat-security
+      name: "{{ netstat_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
+      purge_rules_egress: false
+      purge_rules: false
       rules:
         - proto: tcp
           from_port: 22

--- a/roles/bootnode-access/tasks/ec2.yml
+++ b/roles/bootnode-access/tasks/ec2.yml
@@ -4,7 +4,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: bootnode-security
+      name: "{{ bootnode_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
@@ -14,7 +14,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: bootnode-security
+      name: "{{ bootnode_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -30,7 +30,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: bootnode-security
+      name: "{{ bootnode_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -49,7 +49,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: bootnode-security
+      name: "{{ bootnode_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -65,7 +65,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: bootnode-security
+      name: "{{ bootnode_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -85,7 +85,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: bootnode-security
+      name: "{{ bootnode_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false

--- a/roles/explorer-access/tasks/ec2.yml
+++ b/roles/explorer-access/tasks/ec2.yml
@@ -4,7 +4,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: explorer-security
+      name: "{{ explorer_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
@@ -14,7 +14,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: explorer-security
+      name: "{{ explorer_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -30,7 +30,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: explorer-security
+      name: "{{ explorer_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -49,7 +49,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: explorer-security
+      name: "{{ explorer_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -65,7 +65,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: explorer-security
+      name: "{{ explorer_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -88,7 +88,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: explorer-security
+      name: "{{ explorer_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false

--- a/roles/moc-access/tasks/ec2.yml
+++ b/roles/moc-access/tasks/ec2.yml
@@ -4,7 +4,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: moc-security
+      name: "{{ moc_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
@@ -14,7 +14,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: moc-security
+      name: "{{ moc_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -30,7 +30,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: moc-security
+      name: "{{ moc_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -49,7 +49,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: moc-security
+      name: "{{ moc_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false

--- a/roles/netstat-access/tasks/ec2.yml
+++ b/roles/netstat-access/tasks/ec2.yml
@@ -4,7 +4,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: netstat-security
+      name: "{{ netstat_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
@@ -14,7 +14,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: netstat-security
+      name: "{{ netstat_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -30,7 +30,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: netstat-security
+      name: "{{ netstat_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -49,7 +49,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: netstat-security
+      name: "{{ netstat_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -65,7 +65,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: netstat-security
+      name: "{{ netstat_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false

--- a/roles/validator-access/tasks/ec2.yml
+++ b/roles/validator-access/tasks/ec2.yml
@@ -4,7 +4,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: validator-security
+      name: "{{ validator_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
@@ -14,7 +14,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: validator-security
+      name: "{{ validator_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -30,7 +30,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: validator-security
+      name: "{{ validator_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false
@@ -49,7 +49,7 @@
   ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: validator-security
+      name: "{{ validator_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
       purge_rules_egress: false

--- a/validator.yml
+++ b/validator.yml
@@ -7,9 +7,11 @@
     ec2_group:
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
-      name: validator-security
+      name: "{{ validator_security_group }}"
       description: "Default security group"
       region: "{{ region }}"
+      purge_rules_egress: false
+      purge_rules: false
       rules:
         - proto: tcp
           from_port: 22


### PR DESCRIPTION
This is a cherry-picked commit from master, that is useful in production branches
It changes naming of aws security groups and prevents them from being overwritten if they already exist.
It closes an old issue #43 and is related to a twin PR for Sokol https://github.com/poanetwork/deployment-playbooks/pull/121