### PR TITLE
#125 fix

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,7 +8,6 @@ gathering = implicit
 timeout = 10
 host_key_checking = False
 
-remote_user = root
 ansible_managed = This file is managed by ansible
 
 [ssh_connection]

--- a/group_vars/all.yml.example
+++ b/group_vars/all.yml.example
@@ -42,7 +42,8 @@ PARITY_BIN_SHA256: "3604a030388cd2c22ebe687787413522106c697610426e09b3c5da4fe70b
 SCRIPTS_MOC_BRANCH: "master"
 SCRIPTS_VALIDATOR_BRANCH: "master"
 
-
+#Explicitly specifies method of privilege escalation
+become_method: sudo
 
 ###The following variables are node-specific. They should be kept in group_vars/<node>.yml set of files. Alternatively they can be specifed at <role>/vars/main.yml file.
 
@@ -142,10 +143,6 @@ api_version: "9773b5b"
 
 
 ###Those variables are intended to be specified by users. They don't have any reasonable defaults. Those variables should be specified at group_vars/<role> folder or at <role>/vars/main.yml.
-
-#Specifies the SSH public key file, that will be added to remote 'root' user as an authorized key
-#ssh_root:
-#    - "{{ lookup('file', 'files/admins.pub') }}"
 
 #Validator's mining keyfile content (json string)
 #MINING_KEYFILE: "INSERT HERE"

--- a/group_vars/all.yml.network
+++ b/group_vars/all.yml.network
@@ -1,10 +1,10 @@
 ---
+
+become_method: sudo
+
 ansible_user: ubuntu
 
 ansible_python_interpreter: /usr/bin/python3
-
-ssh_root:
-    - "{{ lookup('file', 'files/admins.pub') }}"
 
 image: "ami-0b383171"
 region: "us-east-1"

--- a/roles/poa-netstats/tasks/main.yml
+++ b/roles/poa-netstats/tasks/main.yml
@@ -32,7 +32,6 @@
 - name: install npm netstats
   npm:
     path: "{{ home }}/eth-net-intelligence-api"
-  become: true
   become_user: "{{ username }}"
   notify:
     - restart poa-netstats

--- a/roles/poa-netstats/tasks/main.yml
+++ b/roles/poa-netstats/tasks/main.yml
@@ -29,9 +29,10 @@
 - name: Change owner and group of eth-net-intelligence-api files
   file: path={{ home }}/eth-net-intelligence-api owner={{ username }} group={{ username }} recurse=yes
 
-- name: install npm netstats
+- name: Install npm netstats
   npm:
     path: "{{ home }}/eth-net-intelligence-api"
+  become: true
   become_user: "{{ username }}"
   notify:
     - restart poa-netstats

--- a/roles/preconf/defaults/main.yml
+++ b/roles/preconf/defaults/main.yml
@@ -8,6 +8,3 @@ home: "/home/{{ username }}"
 GENESIS_NETWORK_NAME: "PoA"
 MAIN_REPO_FETCH: "poanetwork"
 GENESIS_BRANCH: "master"
-
-ssh_root:
-    - "{{ lookup('file', 'files/admins.pub') }}"

--- a/roles/preconf/tasks/main.yml
+++ b/roles/preconf/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: Add ssh keys for root
-  authorized_key: user=root key={{ item }} state=present exclusive=yes
-  with_items: "{{ ssh_root }}"
 
 - import_tasks: ssh.yml
 - import_tasks: packages.yml


### PR DESCRIPTION
It is not necessary anymore for playbooks to connect as `root` to remote host anymore. In order to enhance security, play that is adding SSH key to `root` authorized list is removed at this PR.