### PR TITLE
(Core) set max peers and snaphost peers options

### DIFF
--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -9,10 +9,10 @@ auto_update = "all"
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
+max_peers = 100
+snapshot_peers = 25
 {% if bootnode_archive|default("off") == "on" %}
-snapshot_peers = 500
 discovery = false
-allow_ips = "public"
 {% endif %}
 
 [rpc]

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -10,7 +10,6 @@ reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
 max_peers = 100
-snapshot_peers = 25
 {% if validator_archive|default("off") == "on" %}
 discovery = false
 {% endif %}

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -9,10 +9,10 @@ auto_update = "all"
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
+max_peers = 100
+snapshot_peers = 25
 {% if validator_archive|default("off") == "on" %}
-snapshot_peers = 500
 discovery = false
-allow_ips = "public"
 {% endif %}
 
 [rpc]


### PR DESCRIPTION
Refactor and set values of `max_peers = 100` (for bootnodes and validators) and of `snapshot_peers = 25` (only for bootnodes).
This should improve peers discovery.