### PR TITLE
Merge latest changes from prod branches

### DIFF
--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -9,10 +9,10 @@ auto_update = "all"
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
+max_peers = 100
+snapshot_peers = 25
 {% if bootnode_archive|default("off") == "on" %}
-snapshot_peers = 500
 discovery = false
-allow_ips = "public"
 {% endif %}
 
 [rpc]

--- a/roles/nginx/templates/default.conf.j2
+++ b/roles/nginx/templates/default.conf.j2
@@ -5,14 +5,14 @@ server {
 
   ssl_certificate      /etc/nginx/ssl/server.crt;
   ssl_certificate_key  /etc/nginx/ssl/server.key;
-  ssl_dhparam  	       /etc/nginx/ssl/dhparam.pem;
+  ssl_dhparam          /etc/nginx/ssl/dhparam.pem;
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
   ssl_prefer_server_ciphers on;
   ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
 
   server_name _;
+  client_max_body_size 128k;
 
-    
   access_log /dev/null;
 
   location / {

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -9,10 +9,9 @@ auto_update = "all"
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
+max_peers = 100
 {% if validator_archive|default("off") == "on" %}
-snapshot_peers = 500
 discovery = false
-allow_ips = "public"
 {% endif %}
 
 [rpc]


### PR DESCRIPTION
Set values for 
* `max_peers` (bootnode & validator)
* `snapshot_peers` (bootnode)
* `client_max_body_size` (nginx)

These are latest updates from sokol and core branches (see https://github.com/poanetwork/deployment-playbooks/pull/151, https://github.com/poanetwork/deployment-playbooks/pull/148)