### PR TITLE
Fix instance names

### DIFF
--- a/aws/explorer.yml
+++ b/aws/explorer.yml
@@ -36,7 +36,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ bootnode_instance_name }}"
+        id: "{{ explorer_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"

--- a/aws/moc.yml
+++ b/aws/moc.yml
@@ -36,7 +36,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ bootnode_instance_name }}"
+        id: "{{ moc_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"

--- a/aws/netstat.yml
+++ b/aws/netstat.yml
@@ -36,7 +36,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ bootnode_instance_name }}"
+        id: "{{ netstat_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"

--- a/aws/validator.yml
+++ b/aws/validator.yml
@@ -36,7 +36,7 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ bootnode_instance_name }}"
+        id: "{{ validator_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"


### PR DESCRIPTION
AWS instance names were using `bootnode_instance_name`