### PR TITLE
(CORE) Update default parity version to 1.11.8

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -52,7 +52,7 @@ BLK_GAS_LIMIT: "6700000"
 NODE_PWD: "node.pwd"
 
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.11.8/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_LOC: "https://releases.parity.io/v1.11.8/x86_64-unknown-linux-gnu/parity"
 PARITY_BIN_SHA256: "fbb349dc45e5de1b337880622be88c375998bf2ce69bb402eb9fe60f63b361f9"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""

--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -52,8 +52,8 @@ BLK_GAS_LIMIT: "6700000"
 NODE_PWD: "node.pwd"
 
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://s3.us-east-2.amazonaws.com/poa-builds-parity-published/1.10.6/parity"
-PARITY_BIN_SHA256: "539f4788fbd605a9cd87b5bf747b27ae05b8a4080b26aa3da645b0446fa9f9cc"
+PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.11.8/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "fbb349dc45e5de1b337880622be88c375998bf2ce69bb402eb9fe60f63b361f9"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -22,7 +22,7 @@ region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.11.8/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_LOC: "https://releases.parity.io/v1.11.8/x86_64-unknown-linux-gnu/parity"
 PARITY_BIN_SHA256: "fbb349dc45e5de1b337880622be88c375998bf2ce69bb402eb9fe60f63b361f9"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -22,8 +22,8 @@ region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://s3.us-east-2.amazonaws.com/poa-builds-parity-published/1.10.6/parity"
-PARITY_BIN_SHA256: "539f4788fbd605a9cd87b5bf747b27ae05b8a4080b26aa3da645b0446fa9f9cc"
+PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.11.8/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "fbb349dc45e5de1b337880622be88c375998bf2ce69bb402eb9fe60f63b361f9"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 


### PR DESCRIPTION
Update default parity version in playbooks
Cousin of https://github.com/poanetwork/deployment-playbooks/pull/158