### PR TITLE
Update default instance sizes to t2.xlarge, update default ami

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -23,7 +23,7 @@ access_key: "INSERT KEY HERE"
 secret_key: "INSERT SECRET HERE"
 
 awskeypair_name: "keypairname"
-image: "ami-0b383171"
+image: "ami-5c150e23"
 region: "us-east-1"
 vpc_subnet_id: "subnet-ID-number"
 
@@ -58,7 +58,7 @@ ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 
 #bootnode
-bootnode_instance_type: "t2.large"
+bootnode_instance_type: "t2.xlarge"
 bootnode_instance_name: "bootnode"
 bootnode_count_instances: "1"
 bootnode_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-bootnode-security"
@@ -66,27 +66,27 @@ bootnode_archive: "off"
 bootnode_orchestrator: "off"
 
 #netstat
-netstat_instance_type: "t2.large"
+netstat_instance_type: "t2.xlarge"
 netstat_instance_name: "netstat"
 netstat_count_instances: "1"
 netstat_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-netstat-security"
 
 #validator
-validator_instance_type: "t2.large"
+validator_instance_type: "t2.xlarge"
 validator_instance_name: "validator"
 validator_count_instances: "1"
 validator_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-validator-security"
 validator_archive: "off"
 
 #moc
-moc_instance_type: "t2.large"
+moc_instance_type: "t2.xlarge"
 moc_instance_name: "moc"
 moc_count_instances: "1"
 moc_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-moc-security"
 moc_archive: "off"
 
 #explorer
-explorer_instance_type: "t2.large"
+explorer_instance_type: "t2.xlarge"
 explorer_instance_name: "explorer"
 explorer_count_instances: "1"
 explorer_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-explorer-security"

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -17,7 +17,7 @@ ntpservers:
   - "server 2.us.pool.ntp.org"
   - "server 3.us.pool.ntp.org"
 
-image: "ami-0b383171"
+image: "ami-5c150e23"
 region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
@@ -37,7 +37,7 @@ MOC_ADDRESS: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"
 BLK_GAS_LIMIT: "8000000"
 
 #bootnode
-bootnode_instance_type: "t2.large"
+bootnode_instance_type: "t2.xlarge"
 bootnode_instance_name: "bootnode"
 bootnode_count_instances: "1"
 bootnode_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-bootnode-security"
@@ -45,13 +45,13 @@ bootnode_archive: "off"
 bootnode_orchestrator: "off"
 
 #netstat
-netstat_instance_type: "t2.large"
+netstat_instance_type: "t2.xlarge"
 netstat_instance_name: "netstat"
 netstat_count_instances: "1"
 netstat_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-netstat-security"
 
 #validator
-validator_instance_type: "t2.large"
+validator_instance_type: "t2.xlarge"
 validator_instance_name: "validator"
 validator_count_instances: "1"
 validator_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-validator-security"
@@ -65,7 +65,7 @@ moc_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-moc-security"
 moc_archive: "off"
 
 #explorer
-explorer_instance_type: "t2.large"
+explorer_instance_type: "t2.xlarge"
 explorer_instance_name: "explorer"
 explorer_count_instances: "1"
 explorer_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-explorer-security"


### PR DESCRIPTION
1. Use larger instance type by default (t2.large -> t2.xlarge)
2. Update to the latest aws image
