### PR TITLE
Remove payout script cronjob (after HF)

### DIFF
--- a/roles/validator/tasks/main.yml
+++ b/roles/validator/tasks/main.yml
@@ -44,6 +44,3 @@
   become_user: "{{ username }}"
   notify:
     - restart poa-netstats
-
-- name: Install Payout task.
-  template: src=transferRewardToPayoutKey.j2 dest=/etc/cron.hourly/transferRewardToPayoutKey owner=root group=root mode=0755


### PR DESCRIPTION
Don't merge yet (after HF + 24hrs)

After hardfork that will introduce BlockReward contract, there won't be any need in payout script, so this PR removes installation of cronjob for payout script.