### PR TITLE
Fix defaults in EC2 creation (176 issue)

### DIFF
--- a/aws/bootnode.yml
+++ b/aws/bootnode.yml
@@ -12,7 +12,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: 22
@@ -44,7 +44,7 @@
         count: "{{ bootnode_count_instances }}"
         wait: yes
         region: "{{ region }}"
-        vpc_subnet_id: "{{ vpc_subnet_id }}"
+        vpc_subnet_id: "{{ vpc_subnet_id | default('') }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
       register:   ec2

--- a/aws/bootnode.yml
+++ b/aws/bootnode.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: bootnode
 
 

--- a/aws/explorer.yml
+++ b/aws/explorer.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: explorer
 
 

--- a/aws/explorer.yml
+++ b/aws/explorer.yml
@@ -12,7 +12,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: 22
@@ -44,7 +44,7 @@
         count: "{{ explorer_count_instances }}"
         wait: yes
         region: "{{ region }}"
-        vpc_subnet_id: "{{ vpc_subnet_id }}"
+        vpc_subnet_id: "{{ vpc_subnet_id | default('') }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
       register:   ec2

--- a/aws/moc.yml
+++ b/aws/moc.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: moc
 
 

--- a/aws/moc.yml
+++ b/aws/moc.yml
@@ -12,7 +12,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: 22
@@ -44,7 +44,7 @@
         count: "{{ moc_count_instances }}"
         wait: yes
         region: "{{ region }}"
-        vpc_subnet_id: "{{ vpc_subnet_id }}"
+        vpc_subnet_id: "{{ vpc_subnet_id | default('') }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
       register:   ec2

--- a/aws/netstat.yml
+++ b/aws/netstat.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: netstat
 
 

--- a/aws/netstat.yml
+++ b/aws/netstat.yml
@@ -12,7 +12,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: 22
@@ -44,7 +44,7 @@
         count: "{{ netstat_count_instances }}"
         wait: yes
         region: "{{ region }}"
-        vpc_subnet_id: "{{ vpc_subnet_id }}"
+        vpc_subnet_id: "{{ vpc_subnet_id | default('') }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
       register:   ec2

--- a/aws/roles/bootnode-access/tasks/ec2.yml
+++ b/aws/roles/bootnode-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ bootnode_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/bootnode-access/tasks/ec2.yml
+++ b/aws/roles/bootnode-access/tasks/ec2.yml
@@ -8,7 +8,7 @@
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
 
 - name: Add ssh access
   delegate_to: localhost
@@ -20,7 +20,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"
@@ -40,7 +40,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: 443
@@ -57,7 +57,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"
@@ -78,7 +78,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"

--- a/aws/roles/explorer-access/tasks/ec2.yml
+++ b/aws/roles/explorer-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ explorer_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/explorer-access/tasks/ec2.yml
+++ b/aws/roles/explorer-access/tasks/ec2.yml
@@ -8,7 +8,7 @@
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
 
 - name: Add ssh access
   delegate_to: localhost
@@ -20,7 +20,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"
@@ -40,7 +40,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: 443
@@ -57,7 +57,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"
@@ -81,7 +81,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"

--- a/aws/roles/moc-access/tasks/ec2.yml
+++ b/aws/roles/moc-access/tasks/ec2.yml
@@ -8,7 +8,7 @@
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
 
 - name: Add ssh access
   delegate_to: localhost
@@ -20,7 +20,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"
@@ -40,7 +40,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"

--- a/aws/roles/moc-access/tasks/ec2.yml
+++ b/aws/roles/moc-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ moc_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/netstat-access/tasks/ec2.yml
+++ b/aws/roles/netstat-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ netstat_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/netstat-access/tasks/ec2.yml
+++ b/aws/roles/netstat-access/tasks/ec2.yml
@@ -8,7 +8,7 @@
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
 
 - name: Add ssh access
   delegate_to: localhost
@@ -20,7 +20,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"
@@ -40,7 +40,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: 443
@@ -57,7 +57,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"

--- a/aws/roles/validator-access/tasks/ec2.yml
+++ b/aws/roles/validator-access/tasks/ec2.yml
@@ -8,7 +8,7 @@
       description: "Default security group"
       region: "{{ region }}"
       purge_rules: true
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
 
 - name: Add ssh access
   delegate_to: localhost
@@ -20,7 +20,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"
@@ -40,7 +40,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: "{{ item }}"

--- a/aws/roles/validator-access/tasks/ec2.yml
+++ b/aws/roles/validator-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ validator_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/validator.yml
+++ b/aws/validator.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: validator
 
 

--- a/aws/validator.yml
+++ b/aws/validator.yml
@@ -12,7 +12,7 @@
       region: "{{ region }}"
       purge_rules_egress: false
       purge_rules: false
-      vpc_id: "{{ vpc_id }}"
+      vpc_id: "{{ vpc_id | default('') }}"
       rules:
         - proto: tcp
           from_port: 22
@@ -44,7 +44,7 @@
         count: "{{ validator_count_instances }}"
         wait: yes
         region: "{{ region }}"
-        vpc_subnet_id: "{{ vpc_subnet_id }}"
+        vpc_subnet_id: "{{ vpc_subnet_id | default('') }}"
         volumes: "{{ volumes }}"
         assign_public_ip: yes
       register:   ec2


### PR DESCRIPTION
I've found and tested that if we replace `vpc_id` and `vpc_subnet_id` with empty value Ansible uses the appropriate defaults.