### PR TITLE
Fix `max_peers` and `min_peers` section in node.toml (Master)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,36 @@
 version: 2
 jobs:
+  preconf:
+    docker:
+      - image: poanetwork/terraform-prep
+    working_directory: ~/deployment-terraform/azure
+    environment:
+          ANSIBLE_AZURE_AUTH_SOURCE: env  
+    
+    steps:
+      - run:
+          name: Generate shared workspace folder
+          command: mkdir -p /tmp/workspace
+    
+      - run:
+          name: Set all.yml config
+          command: echo $config_file | base64 --decode > /tmp/workspace/all.yml
+
+      - run:
+          name: set id_rsa.pub
+          command: echo $pub_key > /tmp/workspace/id_rsa.pub
+
+      - run:
+          name: Generate unique prefix for this build
+          command: head /dev/urandom | tr -dc A-Za-z0-9 | head -c 5  | tee /tmp/workspace/prefix
+      
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - all.yml
+            - prefix
+            - id_rsa.pub
+
   build:
     docker:
       - image: poanetwork/terraform-prep
@@ -10,33 +41,41 @@ jobs:
     steps:      
       - run:
           command: cd ~ && rm -R ~/deployment-terraform/ && git clone $terraform_repo ~/deployment-terraform/
+          
       - run:
           command: git checkout $terraform_branch
+      
+      - attach_workspace:
+          at: /tmp/workspace/    
 
       - run:
-          name: adjust configs
-          command: echo $config_file | base64 --decode > ~/deployment-terraform/azure/group_vars/all.yml
+          name: Set unique prefix for this build
+          command: echo 'export tf_prefix=tf_$(cat /tmp/workspace/prefix)_' >> $BASH_ENV
+          
+      - run:
+          name: Copy all.yml file to appropriate folder
+          command: cp /tmp/workspace/all.yml  ~/deployment-terraform/azure/group_vars/all.yml
 
       - run:
-          name: set id_rsa.pub
-          command: echo $pub_key > ~/deployment-terraform/azure/id_rsa.pub
-
-      - run:
-          name: deploy infra
-          command: bash -c "ansible-playbook site.yml -e 'terraform_location=/usr/local/bin/terraform' -e 'backend=true' $build_attr"
+          name: Deploy infra
+          command: bash -c "ansible-playbook site.yml -e 'PUB_KEY_STORE=/tmp/workspace/id_rsa.pub' -e 'terraform_location=/usr/local/bin/terraform' -e 'backend=true' -e 'tf_prefix=$tf_prefix' $build_attr"
           no_output_timeout: 2000
       
       - run:
           name: Save artifacts
-          command: bash -c "ansible-playbook -i ~/deployment-terraform/azure/outputs/latest_deploy_hosts download_outputs.yml -t build -e 'destination=/tmp/artifacts/' -e 'terraform_location=/usr/local/bin/terraform' $build_attr"
+          command: bash -c "ansible-playbook -i ~/deployment-terraform/azure/outputs/latest_deploy_hosts download_outputs.yml -t build -e 'PUB_KEY_STORE=/tmp/workspace/id_rsa.pub' -e 'destination=/tmp/artifacts/' -e 'terraform_location=/usr/local/bin/terraform' $build_attr"
+          
+      - run:
+          name: Save latest hosts output && build prefix
+          command: cp ~/deployment-terraform/azure/outputs/latest_deploy_hosts /tmp/workspace/hosts && cp /tmp/workspace/prefix /tmp/artifacts/prefix
       
       - store_artifacts:
           path: /tmp/artifacts
 
       - persist_to_workspace:
-          root: ~/deployment-terraform/azure/outputs/
+          root: /tmp/workspace
           paths:
-            - latest_deploy_hosts
+            - hosts
   
   test:
     docker:
@@ -51,24 +90,27 @@ jobs:
           command: git checkout $terraform_branch
           
       - attach_workspace:
-          at: /tmp/hosts/
+          at: /tmp/workspace/
 
       - run:
-          name: adjust configs
-          command: echo $config_file | base64 --decode > ~/deployment-terraform/azure/group_vars/all.yml
-
+          name: Copy all.yml file to appropriate folder
+          command: cp /tmp/workspace/all.yml  ~/deployment-terraform/azure/group_vars/all.yml
+          
       - run:
-          name: set id_rsa.pub
-          command: echo $pub_key > ~/deployment-terraform/azure/id_rsa.pub
+          name: Fetch pre-defined prefix to environmental variable
+          command: echo 'export tf_prefix=tf_$(cat /tmp/workspace/prefix)_' >> $BASH_ENV
       
       - run:
           name: check network
-          command: bash -c "ansible-playbook tests.yml -i /tmp/hosts/latest_deploy_hosts -e 'terraform_location=/usr/local/bin/terraform' -e 'backend=true' $tests_attr"
-  
+          command: bash -c "ansible-playbook tests.yml -i /tmp/workspace/hosts -e 'PUB_KEY_STORE=/tmp/workspace/id_rsa.pub' -e 'terraform_location=/usr/local/bin/terraform' -e 'tf_prefix=$tf_prefix' -e 'backend=true' $tests_attr"
+ 
       - run:
           name: Save artifacts
-          command: bash -c "ansible-playbook -i /tmp/hosts/latest_deploy_hosts download_outputs.yml -t tests -e 'destination=/tmp/artifacts/' -e 'terraform_location=/usr/local/bin/terraform' $tests_attr"
+          command: bash -c "ansible-playbook -i /tmp/workspace/hosts download_outputs.yml -t tests -e 'destination=/tmp/artifacts/' -e 'PUB_KEY_STORE=/tmp/workspace/id_rsa.pub' -e 'tf_prefix=$tf_prefix' -e 'terraform_location=/usr/local/bin/terraform' $tests_attr"
   
+      - store_test_results:
+          path: /tmp/artifacts
+
       - store_artifacts:
           path: /tmp/artifacts
 
@@ -86,29 +128,37 @@ jobs:
       - run:
           command: git checkout $terraform_branch
           
+      - attach_workspace:
+          at: /tmp/workspace/
+        
       - run:
-          name: adjust configs
-          command: echo $config_file | base64 --decode > ~/deployment-terraform/azure/group_vars/all.yml
-
-      - run:
-          name: set id_rsa.pub
-          command: echo $pub_key > ~/deployment-terraform/azure/id_rsa.pub
+          name: Fetch pre-defined prefix to environmental variable
+          command: echo 'export tf_prefix=tf_$(cat /tmp/workspace/prefix)_' >> $BASH_ENV
           
       - run:
+          name: Copy all.yml file to appropriate folder
+          command: cp /tmp/workspace/all.yml  ~/deployment-terraform/azure/group_vars/all.yml
+
+      - run:
           name: destroy infra
-          command: bash -c "ansible-playbook destroy.yml -e 'terraform_location=/usr/local/bin/terraform' -e 'backend=true' $destroy_attr"
+          command: bash -c "ansible-playbook destroy.yml -e 'PUB_KEY_STORE=/tmp/workspace/id_rsa.pub' -e 'tf_prefix='$tf_prefix -e 'terraform_location=/usr/local/bin/terraform' -e 'backend=true' -e 'tf_prefix=$tf_prefix' $destroy_attr"
           no_output_timeout: 2000
 
 workflows:
   version: 2
-  test_and_destroy:
+  full:
     jobs:
-      - build
+      - preconf
+      - build:
+          requires:
+            - preconf
       - test:
           requires:
             - build
       - approve_destroy:
           type: approval
+          requires:
+            - preconf
       - destroy:
           requires:
             - approve_destroy

--- a/aws/bootnode.yml
+++ b/aws/bootnode.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: bootnode
 
 

--- a/aws/explorer.yml
+++ b/aws/explorer.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: explorer
 
 

--- a/aws/moc.yml
+++ b/aws/moc.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: moc
 
 

--- a/aws/netstat.yml
+++ b/aws/netstat.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: netstat
 
 

--- a/aws/roles/bootnode-access/tasks/ec2.yml
+++ b/aws/roles/bootnode-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ bootnode_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/explorer-access/tasks/ec2.yml
+++ b/aws/roles/explorer-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ explorer_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/moc-access/tasks/ec2.yml
+++ b/aws/roles/moc-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ moc_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/netstat-access/tasks/ec2.yml
+++ b/aws/roles/netstat-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ netstat_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/roles/validator-access/tasks/ec2.yml
+++ b/aws/roles/validator-access/tasks/ec2.yml
@@ -10,23 +10,6 @@
       purge_rules: true
       vpc_id: "{{ vpc_id }}"
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ validator_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      vpc_id: "{{ vpc_id }}"
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/aws/validator.yml
+++ b/aws/validator.yml
@@ -18,11 +18,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: validator
 
 

--- a/roles/moc/templates/node.toml.j2
+++ b/roles/moc/templates/node.toml.j2
@@ -13,6 +13,8 @@ port = 30303
 snapshot_peers = 500
 discovery = false
 allow_ips = "public"
+min_peers = 5
+max_peers = 10
 {% endif %}
 
 [rpc]
@@ -46,8 +48,6 @@ pruning = "archive"
 pruning_history = 1200
 fat_db = "on"
 cache_size_db = 12000
-min_peers = 5
-max_peers = 10
 {% endif %}
 
 [misc]

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -9,9 +9,12 @@ auto_update = "all"
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
-max_peers = 100
 {% if validator_archive|default("off") == "on" %}
 discovery = false
+min_peers = 5
+max_peers = 10
+{% else %}
+max_peers = 100
 {% endif %}
 
 [rpc]
@@ -45,8 +48,6 @@ pruning = "archive"
 pruning_history = 1200
 fat_db = "on"
 cache_size_db = 12000
-min_peers = 5
-max_peers = 10
 {% endif %}
 
 [misc]


### PR DESCRIPTION
As shown in #174 `max_peers` and `min_peers` variables are set in the wrong (`footprint`) section. The purpose of this PR is to migrate those variables to `network` section at `master` branch.
Related PRs are #186 and #187