### PR TITLE
Fix `max_peers` and `min_peers` section in node.toml (Sokol)

### DIFF
--- a/bootnode.yml
+++ b/bootnode.yml
@@ -17,11 +17,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: bootnode
 
 

--- a/explorer.yml
+++ b/explorer.yml
@@ -17,11 +17,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: explorer
 
 

--- a/moc.yml
+++ b/moc.yml
@@ -17,11 +17,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: moc
 
 

--- a/netstat.yml
+++ b/netstat.yml
@@ -17,11 +17,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: netstat
 
 

--- a/roles/bootnode-access/tasks/ec2.yml
+++ b/roles/bootnode-access/tasks/ec2.yml
@@ -9,22 +9,6 @@
       region: "{{ region }}"
       purge_rules: true
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ bootnode_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/roles/explorer-access/tasks/ec2.yml
+++ b/roles/explorer-access/tasks/ec2.yml
@@ -9,22 +9,6 @@
       region: "{{ region }}"
       purge_rules: true
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ explorer_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/roles/moc-access/tasks/ec2.yml
+++ b/roles/moc-access/tasks/ec2.yml
@@ -9,22 +9,6 @@
       region: "{{ region }}"
       purge_rules: true
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ moc_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/roles/moc/templates/node.toml.j2
+++ b/roles/moc/templates/node.toml.j2
@@ -13,6 +13,8 @@ port = 30303
 snapshot_peers = 500
 discovery = false
 allow_ips = "public"
+min_peers = 5
+max_peers = 10
 {% endif %}
 
 [rpc]
@@ -46,8 +48,6 @@ pruning = "archive"
 pruning_history = 1200
 fat_db = "on"
 cache_size_db = 12000
-min_peers = 5
-max_peers = 10
 {% endif %}
 
 [misc]

--- a/roles/netstat-access/tasks/ec2.yml
+++ b/roles/netstat-access/tasks/ec2.yml
@@ -9,22 +9,6 @@
       region: "{{ region }}"
       purge_rules: true
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ netstat_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/roles/validator-access/tasks/ec2.yml
+++ b/roles/validator-access/tasks/ec2.yml
@@ -9,22 +9,6 @@
       region: "{{ region }}"
       purge_rules: true
 
-- name: Allow outbound traffic
-  delegate_to: localhost
-  ec2_group:
-      ec2_access_key: "{{ access_key }}"
-      ec2_secret_key: "{{ secret_key }}"
-      name: "{{ validator_security_group }}"
-      description: "Default security group"
-      region: "{{ region }}"
-      purge_rules_egress: false
-      purge_rules: false
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
-
 - name: Add ssh access
   delegate_to: localhost
   ec2_group:

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -9,9 +9,12 @@ auto_update = "all"
 reserved_peers="{{ home }}/bootnodes.txt"
 nat="extip:{{ ansible_host }}"
 port = 30303
-max_peers = 100
 {% if validator_archive|default("off") == "on" %}
 discovery = false
+min_peers = 5
+max_peers = 10
+{% else %}
+max_peers = 100
 {% endif %}
 
 [rpc]
@@ -45,8 +48,6 @@ pruning = "archive"
 pruning_history = 1200
 fat_db = "on"
 cache_size_db = 12000
-min_peers = 5
-max_peers = 10
 {% endif %}
 
 [misc]

--- a/validator.yml
+++ b/validator.yml
@@ -17,11 +17,6 @@
           from_port: 22
           to_port: 22
           cidr_ip: 0.0.0.0/0
-      rules_egress:
-        - proto: all
-          from_port: all
-          to_port: all
-          cidr_ip: 0.0.0.0/0
   tags: validator
 
 


### PR DESCRIPTION
As shown in #174 `max_peers` and `min_peers` variables are set in the wrong (`footprint`) section. The purpose of this PR is to migrate those variables to `network` section at `sokol` branch.
Related PRs are #185 and #186