### PR TITLE
Change the way nodejs installed (xDAI)

### DIFF
--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-
-NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
+node_version: 8

--- a/roles/nodejs/tasks/ubuntu.yml
+++ b/roles/nodejs/tasks/ubuntu.yml
@@ -2,15 +2,16 @@
 - name: Ensure apt-transport-https is installed.
   apt: name=apt-transport-https state=present
 
-- name: add nodejs repository key
+- name: Install the gpg key for nodejs LTS
+  become: yes
   apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: "{{ node_key_id }}"
+    url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
     state: present
 
-- name: Add nodejs repository
+- name: Install the nodejs LTS repos
+  become: yes
   apt_repository:
-    repo: 'deb {{ node_source_deb }} {{ansible_distribution_release}} main'
+    repo: "deb https://deb.nodesource.com/node_{{ node_version }}.x {{ ansible_distribution_release }} main"
     state: present
 
 - name: Install nodejs packages


### PR DESCRIPTION
As described at #189, playbooks were broken due to the fact that GPG key, which is used during process of nodejs installation are not valid anymore. This change will allow us to get rid of GPG keys and use link to nodejs repo instead. Also simplifies configuration