### PR TITLE
(SOKOL) Update default parity version to 2.2.5

### DIFF
--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -52,8 +52,8 @@ BLK_GAS_LIMIT: "6700000"
 NODE_PWD: "node.pwd"
 
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.2.1/x86_64-unknown-linux-gnu/parity"
-PARITY_BIN_SHA256: "dfdb0ba6d8847a164600baad7008c1a8715126aca21bb0909e7184f2b3bf2d21"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.2.5/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "5a4c8d947feadc48cae1a85f58845b3129d73f96cc7c13df2df8a780584da947"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 

--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -52,8 +52,8 @@ BLK_GAS_LIMIT: "6700000"
 NODE_PWD: "node.pwd"
 
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://releases.parity.io/v1.11.8/x86_64-unknown-linux-gnu/parity"
-PARITY_BIN_SHA256: "fbb349dc45e5de1b337880622be88c375998bf2ce69bb402eb9fe60f63b361f9"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.2.1/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "dfdb0ba6d8847a164600baad7008c1a8715126aca21bb0909e7184f2b3bf2d21"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -22,8 +22,8 @@ region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.2.1/x86_64-unknown-linux-gnu/parity"
-PARITY_BIN_SHA256: "dfdb0ba6d8847a164600baad7008c1a8715126aca21bb0909e7184f2b3bf2d21"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.2.5/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "5a4c8d947feadc48cae1a85f58845b3129d73f96cc7c13df2df8a780584da947"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -22,8 +22,8 @@ region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://releases.parity.io/v1.11.8/x86_64-unknown-linux-gnu/parity"
-PARITY_BIN_SHA256: "fbb349dc45e5de1b337880622be88c375998bf2ce69bb402eb9fe60f63b361f9"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.2.1/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "dfdb0ba6d8847a164600baad7008c1a8715126aca21bb0909e7184f2b3bf2d21"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 


### PR DESCRIPTION
Update default parity version to `2.2.1`