### PR TITLE
Phahulin patch 2

### DIFF
--- a/group_vars/centos
+++ b/group_vars/centos
@@ -5,7 +5,7 @@ ansible_python_interpreter: /usr/bin/python
 ansible_user: centos
 
 ## Network related variables, that are distro dependent
-PARITY_BIN_LOC: "https://releases.parity.io/v1.10.6/x86_64-unknown-centos-gnu/parity"
-PARITY_BIN_SHA256: "9dd5495cadc39c90b1e40a7b3a449821bab84e55d489a688cf5b1c68c4852254"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.2.5/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "5a4c8d947feadc48cae1a85f58845b3129d73f96cc7c13df2df8a780584da947"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""

--- a/group_vars/ubuntu
+++ b/group_vars/ubuntu
@@ -5,7 +5,7 @@ ansible_python_interpreter: /usr/bin/python3
 ansible_user: ubuntu
 
 ## Network related variables, that are distro dependent
-PARITY_BIN_LOC: "https://s3.us-east-2.amazonaws.com/poa-builds-parity-published/1.10.6/parity"
-PARITY_BIN_SHA256: "539f4788fbd605a9cd87b5bf747b27ae05b8a4080b26aa3da645b0446fa9f9cc"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.2.5/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "5a4c8d947feadc48cae1a85f58845b3129d73f96cc7c13df2df8a780584da947"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""


### PR DESCRIPTION
Update default parity version used in `master` branch to 2.2.5
Closes #201 