### PR TITLE
Fix SSH ciphers used by SSHD and replace private IP with public at node.toml

### DIFF
--- a/roles/bootnode/tasks/main.yml
+++ b/roles/bootnode/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Get public IP
+  ipify_facts:
+  register: public_ip
+
 - name: Create node.toml
   template: src=node.toml.j2 dest={{ home }}/node.toml owner={{ username }} group={{ username }} mode=0644
    

--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -7,7 +7,7 @@ auto_update = "all"
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
-nat="extip:{{ public_ip }}"
+nat="extip:{{ public_ip.ansible_facts.ipify_public_ip }}"
 port = 30303
 max_peers = 100
 snapshot_peers = 25

--- a/roles/bootnode/templates/node.toml.j2
+++ b/roles/bootnode/templates/node.toml.j2
@@ -7,7 +7,7 @@ auto_update = "all"
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
-nat="extip:{{ ansible_host }}"
+nat="extip:{{ public_ip }}"
 port = 30303
 max_peers = 100
 snapshot_peers = 25

--- a/roles/explorer/tasks/main.yml
+++ b/roles/explorer/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Get public IP
+  ipify_facts:
+  register: public_ip
+
 - name: Create node.toml
   template: src=node.toml.j2 dest={{ home }}/node.toml owner={{ username }} group={{ username }} mode=0644
 

--- a/roles/explorer/templates/node.toml.j2
+++ b/roles/explorer/templates/node.toml.j2
@@ -4,7 +4,7 @@ base_path = "parity_data"
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
-nat="extip:{{ public_ip }}"
+nat="extip:{{ public_ip.ansible_facts.ipify_public_ip }}"
 port = 30303
 
 [footprint]

--- a/roles/explorer/templates/node.toml.j2
+++ b/roles/explorer/templates/node.toml.j2
@@ -4,7 +4,7 @@ base_path = "parity_data"
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
-nat="extip:{{ ansible_host }}"
+nat="extip:{{ public_ip }}"
 port = 30303
 
 [footprint]

--- a/roles/moc/tasks/main.yml
+++ b/roles/moc/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Get public IP
+  ipify_facts:
+  register: public_ip
+
 - name: Create node.toml
   template: src=node.toml.j2 dest={{ home }}/node.toml owner={{ username }} group={{ username }} mode=0644
 

--- a/roles/moc/templates/node.toml.j2
+++ b/roles/moc/templates/node.toml.j2
@@ -7,7 +7,7 @@ auto_update = "all"
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
-nat="extip:{{ public_ip }}"
+nat="extip:{{ public_ip.ansible_facts.ipify_public_ip }}"
 port = 30303
 {% if moc_archive|default("off") == "on" %}
 snapshot_peers = 500

--- a/roles/moc/templates/node.toml.j2
+++ b/roles/moc/templates/node.toml.j2
@@ -7,7 +7,7 @@ auto_update = "all"
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
-nat="extip:{{ ansible_host }}"
+nat="extip:{{ public_ip }}"
 port = 30303
 {% if moc_archive|default("off") == "on" %}
 snapshot_peers = 500

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -59,7 +59,7 @@
   openssl_csr:
     path: /etc/nginx/ssl/server.csr
     privatekey_path: /etc/nginx/ssl/server.key
-    common_name: "{{ public_ip }}"
+    common_name: "{{ public_ip.ansible_facts.ipify_public_ip }}"
   when: not cert_file_check.stat.exists
 
 - name: Generate self-signed SSL certificate

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -3,17 +3,10 @@
   package: name=nginx state=present
   tags: nginx
 
-- name: Install Pip (Ubuntu)
+- name: Install Pip
   package:
-    name: "python3-pip"
+    name: "{{ (ansible_python_interpreter | default ('python')).split('/')[-1] }}-pip"
     state: present
-  when: ansible_os_family == "Debian"
-
-- name: Install Pip (CentOS)
-  package:
-    name: "python-pip"
-    state: present
-  when: ansible_os_family == "RedHat"
 
 - name: Ensure OpenSSL dependencies are installed (Ubuntu)
   package:
@@ -37,18 +30,11 @@
     - python-devel
   when: ansible_os_family == "RedHat"
   
-- name: Install pyOpenSSL (Ubuntu).
+- name: Install pyOpenSSL
   pip:
-    executable: pip3
+    executable: "{{ ansible_pip | default('pip') }}"
     name: pyOpenSSL
     state: present
-  when: ansible_os_family == "Debian"
- 
-- name: Install pyOpenSSL (Centos).                                                                      
-  pip:                                                                                                                                  
-    name: pyOpenSSL                                                                                                                     
-    state: present 
-  when: ansible_os_family == "RedHat" 
 
 - name: Create directory for nginx SSL certificates
   file: path=/etc/nginx/ssl state=directory mode=0755
@@ -65,11 +51,15 @@
     size: 4096
   when: not cert_file_check.stat.exists
 
+- name: Get public IP
+  ipify_facts:
+  register: public_ip
+
 - name: Generate SSL certificate request
   openssl_csr:
     path: /etc/nginx/ssl/server.csr
     privatekey_path: /etc/nginx/ssl/server.key
-    common_name: "{{ ansible_host }}"
+    common_name: "{{ public_ip }}"
   when: not cert_file_check.stat.exists
 
 - name: Generate self-signed SSL certificate

--- a/roles/preconf/tasks/ssh.yml
+++ b/roles/preconf/tasks/ssh.yml
@@ -4,8 +4,8 @@
     path: /etc/ssh/sshd_config
     insertafter: '^ServerKeyBits'
     content: |
-      Ciphers aes256-ctr,aes192-ctr,aes128-ctr
-      MACs hmac-sha1,hmac-ripemd160
+      Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+      MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
   notify:
     - restart sshd
 

--- a/roles/validator/tasks/main.yml
+++ b/roles/validator/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Get public IP
+  ipify_facts:
+  register: public_ip
+
 - name: Create node.toml
   template: src=node.toml.j2 dest={{ home }}/node.toml owner={{ username }} group={{ username }} mode=0644
 

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -7,7 +7,7 @@ auto_update = "all"
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
-nat="extip:{{ public_ip }}"
+nat="extip:{{ public_ip.ansible_facts.ipify_public_ip }}"
 port = 30303
 {% if validator_archive|default("off") == "on" %}
 discovery = false

--- a/roles/validator/templates/node.toml.j2
+++ b/roles/validator/templates/node.toml.j2
@@ -7,7 +7,7 @@ auto_update = "all"
 
 [network]
 reserved_peers="{{ home }}/bootnodes.txt"
-nat="extip:{{ ansible_host }}"
+nat="extip:{{ public_ip }}"
 port = 30303
 {% if validator_archive|default("off") == "on" %}
 discovery = false


### PR DESCRIPTION
Fixes #175
Fixes #194, but still not making playbooks fully compatible with Ubuntu 18.

Also modifies the way Python and python-pip is used. (related to #195, but not fixes it). I have decided to remove hardcoded values and replace it with variables that has defaults.