### PR TITLE
Update netstat api version

### DIFF
--- a/roles/poa-netstats/defaults/main.yml
+++ b/roles/poa-netstats/defaults/main.yml
@@ -3,7 +3,7 @@
 MAIN_REPO_FETCH: "poanetwork"
 GENESIS_NETWORK_NAME: "PoA"
 
-api_version: "9773b5b" 
+api_version: "master" 
 
 NODE_FULLNAME: ""
 NODE_ADMIN_EMAIL: ""


### PR DESCRIPTION
Purpose of this PR is to update default API version from old (9773b5b) to the new one.