### PR TITLE
Use the latest version of netstats agent

### DIFF
--- a/roles/poa-netstats/defaults/main.yml
+++ b/roles/poa-netstats/defaults/main.yml
@@ -3,7 +3,7 @@
 MAIN_REPO_FETCH: "poanetwork"
 GENESIS_NETWORK_NAME: "PoA"
 
-api_version: "9773b5b" 
+api_version: "master" 
 
 NODE_FULLNAME: ""
 NODE_ADMIN_EMAIL: ""


### PR DESCRIPTION
Replace hard-coded (and outdated) commit number of netstats version with `master`.