### PR TITLE
Fix ciphers and pip version to support Ubuntu 18.04

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -3,17 +3,10 @@
   package: name=nginx state=present
   tags: nginx
 
-- name: Install Pip (Ubuntu)
+- name: Install Pip
   package:
-    name: "python3-pip"
+    name: "{{ (ansible_python_interpreter | default ('python')).split('/')[-1] }}-pip"
     state: present
-  when: ansible_os_family == "Debian"
-
-- name: Install Pip (CentOS)
-  package:
-    name: "python-pip"
-    state: present
-  when: ansible_os_family == "RedHat"
 
 - name: Ensure OpenSSL dependencies are installed (Ubuntu)
   package:
@@ -37,18 +30,11 @@
     - python-devel
   when: ansible_os_family == "RedHat"
   
-- name: Install pyOpenSSL (Ubuntu).
+- name: Install pyOpenSSL
   pip:
-    executable: pip3
+    executable: "{{ ansible_pip | default('pip') }}"
     name: pyOpenSSL
     state: present
-  when: ansible_os_family == "Debian"
- 
-- name: Install pyOpenSSL (Centos).                                                                      
-  pip:                                                                                                                                  
-    name: pyOpenSSL                                                                                                                     
-    state: present 
-  when: ansible_os_family == "RedHat" 
 
 - name: Create directory for nginx SSL certificates
   file: path=/etc/nginx/ssl state=directory mode=0755

--- a/roles/preconf/tasks/ssh.yml
+++ b/roles/preconf/tasks/ssh.yml
@@ -4,8 +4,8 @@
     path: /etc/ssh/sshd_config
     insertafter: '^ServerKeyBits'
     content: |
-      Ciphers aes256-ctr,aes192-ctr,aes128-ctr
-      MACs hmac-sha1,hmac-ripemd160
+      Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+      MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
   notify:
     - restart sshd
 


### PR DESCRIPTION
Based on https://github.com/poanetwork/deployment-playbooks/pull/208

1. use pip version based on available `python` version
2. use different list of ssh ciphers, which is supported on both `Ubuntu 16.04` and `Ubuntu 18.04`
