### PR TITLE
(Sokol) Fix ciphers for Ubuntu 18.04

### DIFF
--- a/roles/preconf/tasks/ssh.yml
+++ b/roles/preconf/tasks/ssh.yml
@@ -6,8 +6,8 @@
     line: "{{ item }}"
 #    backrefs: yes
   with_items:
-    - 'Ciphers aes256-ctr,aes192-ctr,aes128-ctr'
-    - 'MACs hmac-sha1,hmac-ripemd160'
+    - 'Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+    - 'MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com'
   notify:
     - restart sshd
 


### PR DESCRIPTION
Apply SSH cipher fix for Ubuntu 18.04 (as in https://github.com/poanetwork/deployment-playbooks/pull/229/)