### PR TITLE
(Sokol) Update default parity version to 2.6.5

### DIFF
--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -23,8 +23,8 @@ region: "us-east-1"
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
 
-PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.4/x86_64-unknown-linux-gnu/parity"
-PARITY_BIN_SHA256: "1b5fb1a33eba1f4549d7b33a1e8eba049c98fd1f45b901573ed72623cede05ea"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.5/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "62762f424ffcc9ea939f3e09904d64600c4966045a865cfd94f23cf967213a0d"
 NETHERMIND_ZIP_LOC: "https://github.com/NethermindEth/nethermind/releases/download/1.0.3/nethermind-linux-amd64-1.0.3-712d3ed-20190905.zip"
 NETHERMIND_ZIP_SHA256: "ba4213943e2e7da0d49a4b446114cd971c139cc9b0e04d403f5b4a9e8a31c97f"
 BC_CLIENT: "parity"


### PR DESCRIPTION
Current spec.json is incompatible with this new version, so this PR should be merged together with https://github.com/poanetwork/poa-chain-spec/pull/128