### PR TITLE
Fix aws playbooks

### DIFF
--- a/aws/blockscout.yml
+++ b/aws/blockscout.yml
@@ -31,7 +31,6 @@
   tasks:
   - name: Launch instance
     ec2:
-      id: "{{ blockscout_instance_name }}"
       ec2_access_key: "{{ access_key }}"
       ec2_secret_key: "{{ secret_key }}"
       key_name: "{{ awskeypair_name }}"

--- a/aws/bootnode.yml
+++ b/aws/bootnode.yml
@@ -32,7 +32,6 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ bootnode_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"

--- a/aws/explorer.yml
+++ b/aws/explorer.yml
@@ -32,7 +32,6 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ explorer_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"

--- a/aws/group_vars/all.yml.example
+++ b/aws/group_vars/all.yml.example
@@ -15,12 +15,12 @@ image: "ami-0b383171"
 
 ansible_user: ubuntu
 
-# Python bin location 
+# Python bin location
 
 ansible_python_interpreter: /usr/bin/python3
 
 ##############################################################################
-#  This is Centos specific variables. Please uncomment and use them, if Centos 
+#  This is Centos specific variables. Please uncomment and use them, if Centos
 # is the distro of your choice. AMI id in "image" variable is region specific,
 # so please be aware and select right one here
 ###############################################################################
@@ -32,18 +32,18 @@ ansible_python_interpreter: /usr/bin/python3
 
 #ansible_user: centos
 
-# Python bin location, needed by ansible. Python2 or Python3 may be used in 
+# Python bin location, needed by ansible. Python2 or Python3 may be used in
 # different distros. Centos 7 uses Python2
 
 #ansible_python_interpreter: /usr/bin/python
 
 ################################################################################
 #  This is distro independent AWS related variables. Configure them for your
-# aws infrastructure 
+# aws infrastructure
 ################################################################################
 
 # Access and secret keys, to make access to your AWS possible
- 
+
 access_key: XXXX
 secret_key: XXXX
 
@@ -53,12 +53,12 @@ vpc_id: "vpc-ID-number"
 vpc_subnet_id: "subnet-ID-number"
 
 MAIN_REPO_FETCH: "poanetwork"
-GENESIS_BRANCH: "master"
+GENESIS_BRANCH: "dai-test"
 
 ###Bootnode
 
-bootnode_instance_type: "t2.large"
-bootnode_instance_name: "bootnode"
+bootnode_instance_type: "t2.micro"
+bootnode_instance_name: "bootnode-{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}"
 bootnode_count_instances: "1"
 
 bootnode_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-bootnode-security"
@@ -71,8 +71,8 @@ allow_bootnode_rpc: false
 
 ###Explorer
 
-explorer_instance_type: "t2.large" 
-explorer_instance_name: "explorer"
+explorer_instance_type: "t2.large"
+explorer_instance_name: "explorer-{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}"
 explorer_count_instances: "1"
 
 explorer_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-explorer-security"
@@ -85,32 +85,41 @@ allow_explorer_http: true
 ###Moc
 
 moc_instance_type: "t2.large"
-moc_instance_name: "moc"
+moc_instance_name: "moc-{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}"
 moc_count_instances: "1"
 
 moc_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-moc-security"
 
+allow_moc_ssh: true
+allow_moc_p2p: true
+
 ###Netstat
 
 netstat_instance_type: "t2.large"
-netstat_instance_name: "netstat"
+netstat_instance_name: "netstat-{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}"
 netstat_count_instances: "1"
 
 netstat_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-netstat-security"
 
+allow_netstat_ssh: true
+allow_netstat_http: true
+
 ###Validator
 
 validator_instance_type: "t2.large"
-validator_instance_name: "validator"
+validator_instance_name: "validator-{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}"
 validator_count_instances: "1"
 
 validator_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-validator-security"
 associate_validator_elastic_ip: false
 
+allow_validator_ssh: true
+allow_validator_p2p: true
+
 ###Blockscout
 
 blockscout_instance_type: "t2.large"
-blockscout_instance_name: "blockscout"
+blockscout_instance_name: "blockscout-{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}"
 blockscout_count_instances: "1"
 
 blockscout_security_group: "{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}-blockscout-security"

--- a/aws/group_vars/all.yml.example
+++ b/aws/group_vars/all.yml.example
@@ -57,7 +57,7 @@ GENESIS_BRANCH: "dai-test"
 
 ###Bootnode
 
-bootnode_instance_type: "t2.micro"
+bootnode_instance_type: "t2.large"
 bootnode_instance_name: "bootnode-{{ MAIN_REPO_FETCH }}-{{ GENESIS_BRANCH }}"
 bootnode_count_instances: "1"
 

--- a/aws/moc.yml
+++ b/aws/moc.yml
@@ -31,7 +31,6 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ moc_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"

--- a/aws/netstat.yml
+++ b/aws/netstat.yml
@@ -31,7 +31,6 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ netstat_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"

--- a/aws/validator.yml
+++ b/aws/validator.yml
@@ -32,7 +32,6 @@
   tasks:
     - name: Launch instance
       ec2:
-        id: "{{ validator_instance_name }}"
         ec2_access_key: "{{ access_key }}"
         ec2_secret_key: "{{ secret_key }}"
         key_name: "{{ awskeypair_name }}"


### PR DESCRIPTION
1. Remove idempotent  `id` to prevent errors when creating multiple instances.
2. Fix missing `allow_*` variables for security groups