### PR TITLE
(xDai) Update default parity version to 2.6.5

### DIFF
--- a/group_vars/centos
+++ b/group_vars/centos
@@ -5,7 +5,7 @@ ansible_python_interpreter: /usr/bin/python
 ansible_user: centos
 
 ## Network related variables, that are distro dependent
-PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.1/x86_64-unknown-linux-gnu/parity"
-PARITY_BIN_SHA256: "2178a9ee9656dd7669ba7528bec7ec0d54c93c54c5b693a39efa83fefa496348"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.5/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "62762f424ffcc9ea939f3e09904d64600c4966045a865cfd94f23cf967213a0d"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""

--- a/group_vars/ubuntu
+++ b/group_vars/ubuntu
@@ -5,7 +5,7 @@ ansible_python_interpreter: /usr/bin/python3
 ansible_user: ubuntu
 
 ## Network related variables, that are distro dependent
-PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.2/x86_64-unknown-linux-gnu/parity"
-PARITY_BIN_SHA256: "593c2f622fbb04a4baccd3388b66d2d1b1a5bd207201335ab5b26a3ed95d182f"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.5/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "62762f424ffcc9ea939f3e09904d64600c4966045a865cfd94f23cf967213a0d"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""


### PR DESCRIPTION
Version update is required for Istanbul HF. This PR should be merged together with https://github.com/poanetwork/poa-chain-spec/pull/130