### PR TITLE
(Core) Update default parity version to 2.6.5

### DIFF
--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -22,8 +22,8 @@ region: "us-east-1"
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.2/x86_64-unknown-linux-gnu/parity"
-PARITY_BIN_SHA256: "593c2f622fbb04a4baccd3388b66d2d1b1a5bd207201335ab5b26a3ed95d182f"
+PARITY_BIN_LOC: "https://releases.parity.io/ethereum/v2.6.5/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "62762f424ffcc9ea939f3e09904d64600c4966045a865cfd94f23cf967213a0d"
 ORCHESTRATOR_BIN_LOC: ""
 ORCHESTRATOR_BIN_SHA256: ""
 


### PR DESCRIPTION
Sets default parity version to 2.6.5 compatible with Istanbul HF. Needs to be merged with https://github.com/poanetwork/poa-chain-spec/pull/131